### PR TITLE
Add prebuild target

### DIFF
--- a/src/ExampleMod/ExampleMod.csproj
+++ b/src/ExampleMod/ExampleMod.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="PreBuild.target" />
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>net46</TargetFramework>

--- a/src/ExampleMod/PreBuild.target
+++ b/src/ExampleMod/PreBuild.target
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="ClearReferenceCopyLocalPaths" AfterTargets="ResolveAssemblyReferences">
+    <ItemGroup>
+      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" />
+    </ItemGroup>
+  </Target>
+</Project>


### PR DESCRIPTION
Adds a prebuild target to the example csproj.

This prevents the reference includes from being copied to the output directory. Since the game already has these, it makes sense to exclude them from the output.